### PR TITLE
Cancel onLocationChanged listener

### DIFF
--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -24,11 +24,18 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
   Marker _locationMarker;
   EventChannel _stream = EventChannel('locationStatusStream');
   var location = Location();
+  StreamSubscription<LocationData> _onLocationChangedStreamSubscription;
 
   @override
   void initState() {
     super.initState();
     initialize();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _onLocationChangedStreamSubscription.cancel();
   }
 
   void initialize() {
@@ -71,7 +78,8 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
     printLog("OnSubscribe to location change");
     var location = Location();
     if (await location.requestService()) {
-      location.onLocationChanged().listen((onValue) {
+      _onLocationChangedStreamSubscription =
+          location.onLocationChanged().listen((onValue) {
         _addsMarkerLocationToMarkerLocationStream(onValue);
         setState(() {
           if (onValue.latitude == null || onValue.longitude == null) {
@@ -79,7 +87,7 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
           } else {
             _currentLocation = LatLng(onValue.latitude, onValue.longitude);
           }
-  
+
           var height = 20.0 * (1 - (onValue.accuracy / 100));
           var width = 20.0 * (1 - (onValue.accuracy / 100));
           if (height < 0 || width < 0) {
@@ -116,7 +124,7 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
                   ],
                 );
               });
-  
+
           widget.options.markers.add(_locationMarker);
 
           if (widget.options.updateMapLocationOnPositionChange &&


### PR DESCRIPTION
Fix for when navigating away from the app while the location listener has not been unsubscribed from that causes the following error:

```
// [VERBOSE-2:ui_dart_state.cc(157)] Unhandled Exception: setState() called after dispose(): 
_MapsPluginLayerState#d36b3(lifecycle state: defunct, not mounted, tickers: tracking 0 tickers)
// This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
// The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
// This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
// #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1112:9)
// #1      State.setState (package:flutter/src/widgets/framework.dart:1147:6)
// #2      _MapsPluginLayerState._subscribeToLocationChanges.<anonymous closure> (package:user_location/src/user_location_layer.dart:76:9)
```
