### PR TITLE
Issue #74 | Add option to pause location update stream if widget is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Container(
     ),
 )
 ```
+* `locationUpdateInBackground` if `false`, the location update stream is paused if the app is in the background. Once the app is resumed the stream is resumed as well. Option can be useful to reduce the battery consumption while the app is running in the background. Default: `true`.
+
 ### Run the example
 
 See the `example/` folder for a working example app.

--- a/lib/src/user_location_options.dart
+++ b/lib/src/user_location_options.dart
@@ -25,6 +25,10 @@ class UserLocationOptions extends LayerOptions {
   bool showHeading;
 
   double defaultZoom;
+  // If false the location update stream is paused if the app is in the
+  // background (app lifecycle state inactive and paused). Once the app is
+  // resumed the stream is resumed as well.
+  bool locationUpdateInBackground;
 
   UserLocationOptions(
       {@required this.context,
@@ -43,5 +47,6 @@ class UserLocationOptions extends LayerOptions {
       this.fabWidth: 40,
       this.defaultZoom: 15,
       this.zoomToCurrentLocationOnLoad: false,
-      this.showHeading: true});
+      this.showHeading: true,
+      this.locationUpdateInBackground: true});
 }


### PR DESCRIPTION
Pausing the location update stream when the widget is paused helps to reduce the battery consumption if the app runs in the background.

Referes to #74 .