### PR TITLE
Add option to set the location update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Container(
     ),
 )
 ```
+* `locationUpdateIntervalMs` desired interval for a location updates, in milliseconds. Default: 1000 milliseconds.
+
 ### Run the example
 
 See the `example/` folder for a working example app.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,8 @@ class HomePage extends StatelessWidget {
         fabBottom: 50,
         fabRight: 50,
         verbose: false,
-        onTapFAB: onTapFAB);
+        onTapFAB: onTapFAB,
+        locationUpdateIntervalMs: 1000);
 
     //You can also change the value of updateMapLocationOnPositionChange programatically in runtime.
     //userLocationOptions.updateMapLocationOnPositionChange = false;

--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -113,7 +113,9 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
   Future<void> _subscribeToLocationChanges() async {
     printLog("OnSubscribe to location change");
     var location = Location();
-    if (await location.requestService()) {
+    if (await location.requestService() &&
+        await location.changeSettings(
+            interval: widget.options.locationUpdateIntervalMs)) {
       _onLocationChangedStreamSubscription =
           location.onLocationChanged.listen((onValue) {
         _addsMarkerLocationToMarkerLocationStream(onValue);

--- a/lib/src/user_location_options.dart
+++ b/lib/src/user_location_options.dart
@@ -25,6 +25,10 @@ class UserLocationOptions extends LayerOptions {
   bool showHeading;
 
   double defaultZoom;
+  // Desired interval for location updates, in milliseconds. Only affects
+  // Android; Details see underlying location package:
+  // https://github.com/Lyokone/flutterlocation#public-methods-summary
+  int locationUpdateIntervalMs;
 
   UserLocationOptions(
       {@required this.context,
@@ -43,5 +47,6 @@ class UserLocationOptions extends LayerOptions {
       this.fabWidth: 40,
       this.defaultZoom: 15,
       this.zoomToCurrentLocationOnLoad: false,
-      this.showHeading: true});
+      this.showHeading: true,
+      this.locationUpdateIntervalMs: 1000});
 }


### PR DESCRIPTION
The default update interval of the underlying location package is 1000ms.
For some apps such a high frequency might be useful but for others it
might be useful to reduce the frequency. That helps to save battery.

PS: I'm still working in #76. But I thought this one here would be useful as well. At least my user don't move so much in a second :D 