### PR TITLE
Fixed dispose & added a safety check in setState

### DIFF
--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -55,10 +55,17 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
     _locationStatusChangeSubscription?.cancel();
     _onLocationChangedStreamSubscription?.cancel();
     _compassStreamSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  void setState(fn) {
+    if (mounted) {
+      super.setState(fn);
+    }
   }
 
   @override


### PR DESCRIPTION
While using the library I kept getting exceptions about calling things after dispose was called inside _MapsPluginLayerState. Flutter docs say that overrides of dispose() should call super.dispose() at the very end, after moving it there the exceptions have gone away and the plugin is still working as before.
Overriding setState to check if the widget is still mounted also prevents exceptions that can sometimes be thrown if the widget gets disposed of while some async functions spawned by it are still running.
It fixed the issues in my project so I think it could safely be merged.