### PR TITLE
Fixing Location Updates are not turned off in Inactive State on Android

### DIFF
--- a/android/src/main/kotlin/com/example/user_location/UserLocationPlugin.kt
+++ b/android/src/main/kotlin/com/example/user_location/UserLocationPlugin.kt
@@ -13,11 +13,15 @@ import io.flutter.plugin.common.EventChannel.StreamHandler
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Bundle
+import android.util.Log
 
 
 class UserLocationPlugin: MethodCallHandler {
   companion object {
-    @JvmStatic
+      var listener: LocationListener? = null
+      var locationManager: LocationManager? = null
+
+              @JvmStatic
     fun registerWith(registrar: Registrar) {
       val channel = MethodChannel(registrar.messenger(), "user_location")
       channel.setMethodCallHandler(UserLocationPlugin())
@@ -27,7 +31,7 @@ class UserLocationPlugin: MethodCallHandler {
      eventChannel.setStreamHandler(
             object: StreamHandler {
                 override fun onListen(p0: Any?, p1: EventSink) {
-                    val listener = object : LocationListener {
+                    listener = object : LocationListener {
                         override fun onLocationChanged(location: android.location.Location) {
                         }
 
@@ -44,13 +48,14 @@ class UserLocationPlugin: MethodCallHandler {
                         }
                     }
 
-                    val locationManager = registrar.activeContext().getSystemService(Context.LOCATION_SERVICE) as LocationManager
-                    locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER,
+                    locationManager = registrar.activeContext().getSystemService(Context.LOCATION_SERVICE) as LocationManager
+                    locationManager?.requestLocationUpdates(LocationManager.GPS_PROVIDER,
                             2000,
                             10f, listener)
 
                 }
                 override fun onCancel(p0: Any?) {
+                    locationManager?.removeUpdates(listener)
                 }
             }
      )

--- a/android/src/main/kotlin/com/example/user_location/UserLocationPlugin.kt
+++ b/android/src/main/kotlin/com/example/user_location/UserLocationPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.EventChannel.StreamHandler
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Bundle
-import android.util.Log
 
 
 class UserLocationPlugin: MethodCallHandler {

--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -1,4 +1,3 @@
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -1,3 +1,6 @@
+import 'dart:developer';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -75,12 +78,18 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
       switch (state) {
         case AppLifecycleState.inactive:
         case AppLifecycleState.paused:
-          _locationStatusChangeSubscription?.cancel();
+          if (Platform.isAndroid) {
+            _locationStatusChangeSubscription?.cancel();
+          }
           _onLocationChangedStreamSubscription?.cancel();
           break;
         case AppLifecycleState.resumed:
-          _handleLocationStatusChanges();
-          _subscribeToLocationChanges();
+          if (Platform.isAndroid) {
+            _handleLocationStatusChanges();
+            _subscribeToLocationChanges();
+          } else {
+            _onLocationChangedStreamSubscription?.resume();
+          }
           break;
         case AppLifecycleState.detached:
           break;

--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -75,10 +75,12 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
       switch (state) {
         case AppLifecycleState.inactive:
         case AppLifecycleState.paused:
+          _locationStatusChangeSubscription?.cancel();
           _onLocationChangedStreamSubscription?.cancel();
           break;
         case AppLifecycleState.resumed:
-          _onLocationChangedStreamSubscription?.resume();
+          _handleLocationStatusChanges();
+          _subscribeToLocationChanges();
           break;
         case AppLifecycleState.detached:
           break;


### PR DESCRIPTION
This PR fixes the Issue reported here: https://github.com/igaurab/user_location_plugin/issues/78

Previous Solution did turn off Location Updates while in Background on iOS but it did not for Android.
When Android App was in Background/Inactive state the location updates were not turned off even when setting the Flag `locationUpdateInBackground` to false. This PR fixes that issue by turning off the MethodChannel stream subscription which triggers turning off location updates in Android platform code.