### PR TITLE
Fix markerWidget

### DIFF
--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -175,22 +175,32 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
                         ),
                       ),
                     ),
-                  Container(
-                    height: 20.0,
-                    width: 20.0,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: Colors.blue[300].withOpacity(0.7),
-                    ),
-                  ),
                   widget.options.markerWidget ??
-                      Container(
-                        height: 10,
-                        width: 10,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: Colors.blueAccent,
-                        ),
+                      Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: Container(
+                              height: 20,
+                              width: 20,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.blue[300].withOpacity(0.7),
+                              ),
+                            ),
+                          ),
+                          Align(
+                            alignment: Alignment.center,
+                            child: Container(
+                              height: 10,
+                              width: 10,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.blueAccent,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                 ],
               );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   location: ^3.0.0
-  flutter_map: ^0.10.1
+  flutter_map: ^0.11.0
   flutter_compass: ^0.4.1
 
 dev_dependencies:


### PR DESCRIPTION
When a user adds a custom `markerWidget` then only half the previous marker was replaced.